### PR TITLE
Add a wrapper around node-gettext with Nextcloud-style replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ npm i -S @nextcloud/l10n
 
 ## Usage
 
+### OC.L10n abstraction
+
+You can use helpers in this package in order generate code that also works when it's not loaded on a Nextcloud page. This is primary useful for testing. The logic will just return the original string if the global variable `OC` isn't found.
+
 In order to not break the l10n string extraction scripts, make sure to alias the imported function to match the legacy syntax:
 
 ```js
@@ -22,3 +26,46 @@ import {translate as t, translatePlural as n} from '@nextcloud/l10n'
 t('myapp', 'Hello!')
 n('myapp', '%n cloud', '%n clouds', 100)
 ```
+
+See the [localization docs](https://docs.nextcloud.com/server/stable/developer_manual/app/view/l10n.html) for more info.
+
+### Independent translation
+
+You can use this package to translate your app or library independent of Nextcloud. For that you need .po(t) files. These can be extracted with [gettext-extractor](https://github.com/lukasgeiter/gettext-extractor).
+
+```js
+import { getGettextBuilder } from '@nextcloud/l10n/gettext'
+
+const lang = 'sv'
+const po = ... // Use https://github.com/smhg/gettext-parser to read and convert your .po(t) file
+
+const gt = getGettextBuilder()
+    .detectLocale()
+    .addTranslation('sv', po)
+    .build()
+```
+
+#### Translate single string
+
+```js
+gt.gettext('my source string')
+```
+
+#### Placeholders
+
+```js
+gt.gettext('this is a {placeholder}. and this is {key2}', {
+    placeholder: 'test',
+    key2: 'also a test',
+})
+```
+
+See [the developer docs for general guidelines](https://docs.nextcloud.com/server/latest/developer_manual/app/view/l10n.html).
+
+#### Translate plurals
+
+```js
+gt.ngettext('%n Mississippi', '%n Mississippi', 3)
+```
+
+See [the developer docs for general guidelines](https://docs.nextcloud.com/server/latest/developer_manual/app/view/l10n.html).

--- a/babel.config.js
+++ b/babel.config.js
@@ -8,5 +8,8 @@ module.exports = {
                 corejs: "3.0.0",
             },
         ],
-    ]
+    ],
+    "plugins": [
+        "transform-class-properties",
+    ],
 };

--- a/lib/gettext.ts
+++ b/lib/gettext.ts
@@ -1,0 +1,73 @@
+import GetText from "node-gettext"
+
+import { getLanguage } from "."
+
+class GettextBuilder {
+
+    private locale?: string
+    private translations = {}
+
+    setLanguage(language: string): GettextBuilder {
+        this.locale = language
+        return this
+    }
+
+    detectLocale(): GettextBuilder {
+        return this.setLanguage(getLanguage())
+    }
+
+    addTranslation(language: string, data: any): GettextBuilder {
+        this.translations[language] = data
+        return this
+    }
+
+    build(): GettextWrapper {
+        return new GettextWrapper(this.locale || 'en', this.translations)
+    }
+
+}
+
+class GettextWrapper {
+
+    private gt: GetText
+
+    constructor(locale: string, data: any) {
+        this.gt = new GetText()
+
+        for (let key in data) {
+            this.gt.addTranslations(key, 'messages', data[key])
+        }
+
+        this.gt.setLocale(locale)
+    }
+
+    private subtitudePlaceholders(translated: string, vars: object): string {
+        return translated.replace(/{([^{}]*)}/g, (a, b) => {
+            const r = vars[b]
+            if (typeof r === 'string' || typeof r === 'number') {
+                return r.toString()
+            } else {
+                return a
+            }
+        })
+    }
+
+    gettext(original: string, placeholders: object = {}): string {
+        return this.subtitudePlaceholders(
+            this.gt.gettext(original),
+            placeholders
+        )
+    }
+
+    ngettext(singular: string, plural: string, count: number, placeholders: object = {}): string {
+        return this.subtitudePlaceholders(
+            this.gt.ngettext(singular, plural, count).replace(/%n/g, count.toString()),
+            placeholders
+        )
+    }
+
+}
+
+export function getGettextBuilder() {
+    return new GettextBuilder()
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2742,6 +2742,12 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/node-gettext": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node-gettext/-/node-gettext-2.0.1.tgz",
+      "integrity": "sha512-5UCSuDsP7zBwQtBPoJ9Ni0T96+Fuxus7/cF39ZoP319aj7kdsvFR5Zhu5P1IpA3X8PEvED/e8OnFOlFigqfg5A==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -2952,6 +2958,88 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
     },
     "babel-jest": {
       "version": "25.1.0",
@@ -3440,6 +3528,15 @@
         }
       }
     },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
@@ -3471,6 +3568,24 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+      "dev": true
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
     "babel-preset-jest": {
       "version": "25.1.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.1.0.tgz",
@@ -3481,6 +3596,88 @@
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
         "babel-plugin-jest-hoist": "^25.1.0"
       }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
     },
     "backbone": {
       "version": "1.4.0",
@@ -3852,6 +4049,12 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -4077,6 +4280,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -5085,6 +5297,37 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "gettext-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-4.0.2.tgz",
+      "integrity": "sha512-JPCBpGzm01te+nTenJwWqKDzixYPY4pInedixpcMl4GPEJeia/cH2TJCh32IggDrrLYrzqA8OitXZLpBdrx4Gg==",
+      "dev": true,
+      "requires": {
+        "content-type": "^1.0.4",
+        "encoding": "^0.1.12",
+        "readable-stream": "^3.4.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "dev": true
+        }
+      }
+    },
     "glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -5184,6 +5427,23 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
       }
     },
     "has-flag": {
@@ -7282,6 +7542,11 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -7494,6 +7759,14 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-gettext": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-gettext/-/node-gettext-2.0.0.tgz",
+      "integrity": "sha1-8dwSN83FRvUVk9o0AwS4vrpbhSU=",
+      "requires": {
+        "lodash.get": "^4.4.2"
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -7994,6 +8267,12 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.1",
@@ -8629,7 +8908,6 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -9037,8 +9315,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "util.promisify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "babel ./lib --out-dir dist --extensions '.ts,.tsx' --source-maps && tsc --emitDeclarationOnly",
-    "build:doc": "typedoc --excludeNotExported --mode file --out dist/doc lib/index.ts && touch dist/doc/.nojekyll",
+    "build:doc": "typedoc --excludeNotExported --mode file --out dist/doc lib && touch dist/doc/.nojekyll",
     "check-types": "tsc",
     "dev": "babel ./lib --out-dir dist --extensions '.ts,.tsx' --watch",
     "test": "jest",
@@ -23,7 +23,8 @@
     "url": "https://github.com/nextcloud/nextcloud-l10n"
   },
   "dependencies": {
-    "core-js": "3.6.4"
+    "core-js": "3.6.4",
+    "node-gettext": "^2.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.8.4",
@@ -32,7 +33,10 @@
     "@babel/preset-typescript": "7.8.3",
     "@nextcloud/browserslist-config": "^1.0.0",
     "@nextcloud/typings": "^0.1.6",
+    "@types/node-gettext": "^2.0.1",
     "babel-jest": "^25.1.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "gettext-parser": "^4.0.2",
     "jest": "^25.1.0",
     "typedoc": "^0.16.7",
     "typescript": "3.7.5"

--- a/test/gettext.test.js
+++ b/test/gettext.test.js
@@ -1,0 +1,128 @@
+import { po } from 'gettext-parser'
+
+import { getGettextBuilder } from '../lib/gettext'
+
+describe('gettext', () => {
+    it('falls back to the original string', () => {
+        const gt = getGettextBuilder()
+            .setLanguage('de')
+            .build()
+
+        const translation = gt.gettext('Settings')
+
+        expect(translation).toEqual('Settings')
+    })
+
+    it('falls back to the original singular string', () => {
+        const gt = getGettextBuilder()
+            .setLanguage('en')
+            .build()
+
+        const translated = gt.ngettext('%n Setting', '%n Settings', 1)
+
+        expect(translated).toEqual('1 Setting')
+    })
+
+    it('falls back to the original plural string', () => {
+        const gt = getGettextBuilder()
+            .setLanguage('en')
+            .build()
+
+        const translated = gt.ngettext('%n Setting', '%n Settings', 2)
+
+        expect(translated).toEqual('2 Settings')
+    })
+
+    it('detects en as default locale/language', () => {
+        const detected = getGettextBuilder()
+            .detectLocale()
+            .build()
+
+        const manual = getGettextBuilder()
+            .setLanguage('en')
+            .build()
+
+        expect(detected).toEqual(manual)
+    })
+
+    it('used nextcloud-style placeholder replacement', () => {
+        const gt = getGettextBuilder()
+            .setLanguage('de')
+            .build()
+
+        const translation = gt.gettext('I wish Nextcloud were written in {lang}', {
+            lang: 'Rust'
+        })
+
+        expect(translation).toEqual('I wish Nextcloud were written in Rust')
+    })
+
+    it('used nextcloud-style placeholder replacement for plurals', () => {
+        const gt = getGettextBuilder()
+            .setLanguage('de')
+            .build()
+
+        const translation = gt.ngettext('%n {what} Setting', '%n {what} Settings', 2, {
+            what: 'test',
+        })
+
+        expect(translation).toEqual('2 test Settings')
+    })
+
+    it('translates', () => {
+        const pot = `msgid ""
+msgstr ""
+"Last-Translator: Translator, 2020\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sv\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "abc"
+msgstr "def"
+`
+        const gt = getGettextBuilder()
+            .setLanguage('sv')
+            .addTranslation('sv', po.parse(pot))
+            .build()
+
+        const translation = gt.gettext('abc')
+
+        expect(translation).toEqual('def')
+    })
+
+    it('translates plurals', () => {
+        // From https://www.gnu.org/software/gettext/manual/html_node/Translating-plural-forms.html
+        const pot = `msgid ""
+msgstr ""
+"Last-Translator: Translator, 2020\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sv\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "One file removed"
+msgid_plural "%d files removed"
+msgstr[0] "%n slika uklonjenih"
+msgstr[1] "%n slika uklonjenih"
+msgstr[2] "%n slika uklonjenih"
+`
+        const gt = getGettextBuilder()
+            .setLanguage('sv')
+            .addTranslation('sv', po.parse(pot))
+            .build()
+
+        const translation = gt.ngettext('One file removed', '%n files removed', 2)
+
+        expect(translation).toEqual('2 slika uklonjenih')
+    })
+
+    it('does not escape special chars', () => {
+        const gt = getGettextBuilder()
+            .setLanguage('de')
+            .build()
+
+        const translation = gt.gettext('test & stuff')
+
+        expect(translation).toEqual('test & stuff')
+    })
+
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "target": "es5",
         "module": "commonjs",
+        "esModuleInterop": true,
         "declaration": true,
         "outDir": "./dist",
         "strict": true,


### PR DESCRIPTION
Working on https://github.com/nextcloud/nextcloud-vue/pull/854 I realized that node-gettext doesn't handle placeholders like we do in other translations. And there doesn't seem to be like a standard way for doing this. Thus I'm adding a little wrapper around node-gettext here, so we can have a unified translation system for npm packages (and possibly apps if we decide to get fancy and bundle translations).

So this adds
* The aforesaid module
* A builder to get a translation object (gettext offers more functions. but we don't use context nor domain, so I hid them)
* `{placeholder}` style replacement
* `%n` replacement for plurals

Open question(s)
- [x] ~~Do we need sanitization (by default)?~~ let's do this in the apps when necessary. UI strings shouldn't be put into the DOM directly, regardless if it's a user-provided data or a translated string. And framework often escape by default.