### PR TITLE
Only log to console.warn when debug mode is active

### DIFF
--- a/lib/gettext.ts
+++ b/lib/gettext.ts
@@ -6,6 +6,7 @@ class GettextBuilder {
 
     private locale?: string
     private translations = {}
+    private debug = false
 
     setLanguage(language: string): GettextBuilder {
         this.locale = language
@@ -21,8 +22,13 @@ class GettextBuilder {
         return this
     }
 
+    enableDebugMode(): GettextBuilder {
+        this.debug = true
+        return this
+    }
+
     build(): GettextWrapper {
-        return new GettextWrapper(this.locale || 'en', this.translations)
+        return new GettextWrapper(this.locale || 'en', this.translations, this.debug)
     }
 
 }
@@ -31,8 +37,10 @@ class GettextWrapper {
 
     private gt: GetText
 
-    constructor(locale: string, data: any) {
-        this.gt = new GetText()
+    constructor(locale: string, data: any, debug: boolean) {
+        this.gt = new GetText({
+            debug,
+        })
 
         for (let key in data) {
             this.gt.addTranslations(key, 'messages', data[key])

--- a/package-lock.json
+++ b/package-lock.json
@@ -7336,9 +7336,9 @@
       "dev": true
     },
     "node-gettext": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-gettext/-/node-gettext-2.0.0.tgz",
-      "integrity": "sha1-8dwSN83FRvUVk9o0AwS4vrpbhSU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/node-gettext/-/node-gettext-3.0.0.tgz",
+      "integrity": "sha512-/VRYibXmVoN6tnSAY2JWhNRhWYJ8Cd844jrZU/DwLVoI4vBI6ceYbd8i42sYZ9uOgDH3S7vslIKOWV/ZrT2YBA==",
       "requires": {
         "lodash.get": "^4.4.2"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "core-js": "^3.6.4",
-    "node-gettext": "^2.0.0"
+    "node-gettext": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/test/gettext.test.js
+++ b/test/gettext.test.js
@@ -3,6 +3,15 @@ import { po } from 'gettext-parser'
 import { getGettextBuilder } from '../lib/gettext'
 
 describe('gettext', () => {
+
+    beforeEach(() => {
+        jest.spyOn(console, 'warn')
+    })
+
+    afterEach(() => {
+        console.warn.mockRestore()
+    })
+
     it('falls back to the original string', () => {
         const gt = getGettextBuilder()
             .setLanguage('de')
@@ -11,6 +20,27 @@ describe('gettext', () => {
         const translation = gt.gettext('Settings')
 
         expect(translation).toEqual('Settings')
+    })
+
+    it('does not log in production', () => {
+        const gt = getGettextBuilder()
+            .setLanguage('de')
+            .build()
+
+        gt.gettext('Settings')
+
+        expect(console.warn).not.toHaveBeenCalled()
+    })
+
+    it('has optional debug logs', () => {
+        const gt = getGettextBuilder()
+            .setLanguage('de')
+            .enableDebugMode()
+            .build()
+
+        gt.gettext('Settings')
+
+        expect(console.warn).toHaveBeenCalled()
     })
 
     it('falls back to the original singular string', () => {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/nextcloud-l10n/issues/108

As of 3.0.0 the debug more is off by default. As it's still useful sometimes, I added it optionally via the builder.

Ref https://github.com/alexanderwallin/node-gettext/compare/v2.0.0...v3.0.0 for the full diff

I'll publish a minor release once this is in.