### PR TITLE
Set the source locale to 'en'

### DIFF
--- a/lib/gettext.ts
+++ b/lib/gettext.ts
@@ -40,6 +40,7 @@ class GettextWrapper {
     constructor(locale: string, data: any, debug: boolean) {
         this.gt = new GetText({
             debug,
+            sourceLocale: 'en',
         })
 
         for (let key in data) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3269,9 +3269,9 @@
       "dev": true
     },
     "@types/node-gettext": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node-gettext/-/node-gettext-2.0.1.tgz",
-      "integrity": "sha512-5UCSuDsP7zBwQtBPoJ9Ni0T96+Fuxus7/cF39ZoP319aj7kdsvFR5Zhu5P1IpA3X8PEvED/e8OnFOlFigqfg5A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node-gettext/-/node-gettext-3.0.0.tgz",
+      "integrity": "sha512-rLLEKuX6Y+JZgIvny7+O+3GzbqEaWVlRQWe3yRqNi+tprQ/TdHXps7W+xi6Mgts6xDAgCSobX9A+7QwZEkLPAg==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@babel/preset-typescript": "^7.9.0",
     "@nextcloud/browserslist-config": "^1.0.0",
     "@nextcloud/typings": "^0.1.7",
-    "@types/node-gettext": "^2.0.1",
+    "@types/node-gettext": "^3.0",
     "babel-jest": "^25.1.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "gettext-parser": "^4.0.3",


### PR DESCRIPTION
Follow-up to #109. Now you can enable debug mode to see only warnings about the missing translations. The logs are actually helpful then :)