### PR TITLE
Replace dash with underscore for applying proper languages

### DIFF
--- a/lib/gettext.ts
+++ b/lib/gettext.ts
@@ -14,7 +14,7 @@ class GettextBuilder {
     }
 
     detectLocale(): GettextBuilder {
-        return this.setLanguage(getLanguage())
+        return this.setLanguage(getLanguage().replace('-', '_'))
     }
 
     addTranslation(language: string, data: any): GettextBuilder {


### PR DESCRIPTION
- Set Nextcloud language to `de_DE` or any other language that uses a `_` separator in the identifier. 
- Use `@nextcloud/vue` which comes with translations that are depending on the result of getLanguage `https://github.com/nextcloud/nextcloud-l10n/blob/master/lib/index.ts#L31`

`OC.getLanguage` just returns the lang value of the `<html>` element [however `-` are used there instead of `_`](https://github.com/nextcloud/server/blob/cbd20867b59779d7aff5a024e4287206e3c028e0/lib/private/TemplateLayout.php#L158) so the language cannot be found in the provided pot files of `@nextcloud/vue`:

Before:
- Strings don't get translated

After:
- String get properly translated