### PR TITLE
fix: Fix translate substitution when OC is not defined

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -37,10 +37,15 @@ interface TranslationOptions {
  * @param {object} [options] options object
  * @return {string}
  */
-export function translate(app: string, text: string, vars?: object, count?: number, options?: TranslationOptions): string {
+export function translate(app: string, text: string, vars: object = {}, count?: number, options?: TranslationOptions): string {
     if (typeof OC === 'undefined') {
         console.warn('No OC found')
         return text
+            .replace(/%n/g, count?.toString() || '')
+            .replace(/{([^{}]*)}/g, function(a, b) {
+                const r = vars[b]
+                return r
+            })
     }
 
     return OC.L10N.translate(app, text, vars, count, options)
@@ -58,10 +63,15 @@ export function translate(app: string, text: string, vars?: object, count?: numb
  * @return {string}
  */
 
-export function translatePlural(app: string, textSingular: string, textPlural: string, count: number, vars?: object, options?: TranslationOptions): string {
+export function translatePlural(app: string, textSingular: string, textPlural: string, count: number, vars: object = {}, options?: TranslationOptions): string {
     if (typeof OC === 'undefined') {
         console.warn('No OC found')
         return textSingular
+            .replace(/%n/g, count?.toString() || '')
+            .replace(/{([^{}]*)}/g, function(a, b) {
+                const r = vars[b]
+                return r
+            })
     }
 
     return OC.L10N.translatePlural(app, textSingular, textPlural, count, vars, options)


### PR DESCRIPTION
So, I'm not too sure about this. Here is the context

## Context
When testing, we should avoid mocking unnecessary methods and reflect the real execution.
Translate do not just return the string, even if there is no translations for the requested language, it still applies the substitution on the original string.  

## Concerns
Shall we just move [the server code](https://github.com/nextcloud/server/blob/71f698649f578db19a22457cb9d420fb62c10382/core/src/OC/l10n.js) here? Was there a reason for it to call OC instead of shipping working code out of the box? :)

What do you think?

## Refs
- https://github.com/nextcloud/nextcloud-l10n/issues/271
- https://github.com/nextcloud/server/blob/71f698649f578db19a22457cb9d420fb62c10382/core/src/OC/l10n.js