### PR TITLE
Fix "build status" badge in README.mde

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @nextcloud/l10n
 
-[![Build Status](https://travis-ci.com/nextcloud/nextcloud-l10n.svg?branch=master)](https://travis-ci.com/nextcloud/nextcloud-l10n)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/nextcloud/nextcloud-l10n/node.yml?branch=master)](https://github.com/nextcloud/nextcloud-l10n/actions/workflows/node.yml)
 [![npm](https://img.shields.io/npm/v/@nextcloud/l10n.svg)](https://www.npmjs.com/package/@nextcloud/l10n)
 [![Documentation](https://img.shields.io/badge/Documentation-online-brightgreen)](https://nextcloud.github.io/nextcloud-l10n/)
 


### PR DESCRIPTION
Old badge used travis, which was removed some time ago, use github workflow status instead.