### PR TITLE
Add missing test cases for `date.ts`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,9 @@
       },
       "devDependencies": {
         "@nextcloud/browserslist-config": "^2.3.0",
-        "@nextcloud/typings": "^1.0.0",
+        "@nextcloud/typings": "^1.6.0",
         "@rollup/plugin-typescript": "^11.0.0",
+        "@types/jest": "^29.2.5",
         "@types/node-gettext": "^3.0",
         "@zamiell/typedoc-plugin-not-exported": "^0.2.0",
         "check-es-compat": "^2.2.0",
@@ -1146,9 +1147,9 @@
       }
     },
     "node_modules/@nextcloud/typings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.5.0.tgz",
-      "integrity": "sha512-33GMGlajEccf+pKOgFas3DsrRQvEcFlAW6E8P9lVCPt+I4PngRqaF/JDYiRbIWRIkwo8fWbRwfQs37OShiDycQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.6.0.tgz",
+      "integrity": "sha512-5uIsteFy9Z9/ZaNGE8w8SDgJp+FK8/LeRLgfnakC2pU8eNKTPlQfkiYR163oEI5Xu5YzwdIzf6/roIXdNinhrw==",
       "dev": true,
       "dependencies": {
         "@types/jquery": "2.0.60"
@@ -1352,6 +1353,16 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.2.5",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.5.tgz",
+      "integrity": "sha512-H2cSxkKgVmqNHXP7TC2L/WUorrZu8ZigyRywfVzv6EyBlxj39n4C00hjXYQWsbwqgElaj/CiAeSRmk5GoaKTgw==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/jquery": {
@@ -6341,9 +6352,9 @@
       }
     },
     "@nextcloud/typings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.5.0.tgz",
-      "integrity": "sha512-33GMGlajEccf+pKOgFas3DsrRQvEcFlAW6E8P9lVCPt+I4PngRqaF/JDYiRbIWRIkwo8fWbRwfQs37OShiDycQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.6.0.tgz",
+      "integrity": "sha512-5uIsteFy9Z9/ZaNGE8w8SDgJp+FK8/LeRLgfnakC2pU8eNKTPlQfkiYR163oEI5Xu5YzwdIzf6/roIXdNinhrw==",
       "dev": true,
       "requires": {
         "@types/jquery": "2.0.60"
@@ -6504,6 +6515,16 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "29.2.5",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.5.tgz",
+      "integrity": "sha512-H2cSxkKgVmqNHXP7TC2L/WUorrZu8ZigyRywfVzv6EyBlxj39n4C00hjXYQWsbwqgElaj/CiAeSRmk5GoaKTgw==",
+      "dev": true,
+      "requires": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "@types/jquery": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
   },
   "devDependencies": {
     "@nextcloud/browserslist-config": "^2.3.0",
-    "@nextcloud/typings": "^1.0.0",
+    "@nextcloud/typings": "^1.6.0",
     "@rollup/plugin-typescript": "^11.0.0",
+    "@types/jest": "^29.2.5",
     "@types/node-gettext": "^3.0",
     "@zamiell/typedoc-plugin-not-exported": "^0.2.0",
     "check-es-compat": "^2.2.0",

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -1,0 +1,111 @@
+/// <reference types="@nextcloud/typings" />
+declare var window: Nextcloud.v24.WindowWithGlobals
+
+import { getDayNames, getDayNamesMin, getDayNamesShort, getFirstDay, getMonthNames, getMonthNamesShort } from '../lib/date'
+
+describe('date', () => {
+    const orginalWarn = console.warn
+
+    afterAll(() => {
+        console.warn = orginalWarn
+    })
+    beforeEach(() => {
+        console.warn = jest.fn()
+    })
+
+    describe('getFirstDay', () => {
+        // @ts-ignore
+        afterAll(() => { delete window.firstDay })
+
+        it('works without `OC`', () => {
+            expect(getFirstDay()).toBe(1)
+            // Warning as fallback is being used
+            expect(console.warn).toBeCalled()
+        })
+
+        it('works with `OC`', () => {
+            window.firstDay = 3
+            expect(getFirstDay()).toBe(3)
+        })
+    })
+
+    describe('getDayNames', () => {
+        // @ts-ignore
+        afterAll(() => { delete window.dayNames })
+
+        it('works without `OC`', () => {
+            expect(getDayNames().length).toBe(7)
+            // Warning as fallback is being used
+            expect(console.warn).toBeCalled()
+        })
+
+        it('works with `OC`', () => {
+            window.dayNames = 'a'.repeat(7).split('')
+            expect(getDayNames()).toBe(window.dayNames)
+        })
+    })
+
+    describe('getDayNamesShort', () => {
+        // @ts-ignore
+        afterAll(() => { delete window.dayNamesShort })
+
+        it('works without `OC`', () => {
+            expect(getDayNamesShort().length).toBe(7)
+            // Warning as fallback is being used
+            expect(console.warn).toBeCalled()
+        })
+
+        it('works with `OC`', () => {
+            window.dayNamesShort = 'b'.repeat(7).split('')
+            expect(getDayNamesShort()).toBe(window.dayNamesShort)
+        })
+    })
+
+    describe('getDayNamesMin', () => {
+        // @ts-ignore
+        afterAll(() => { delete window.dayNamesMin })
+
+        it('works without `OC`', () => {
+            expect(getDayNamesMin().length).toBe(7)
+            // Warning as fallback is being used
+            expect(console.warn).toBeCalled()
+        })
+
+        it('works with `OC`', () => {
+            window.dayNamesMin = 'c'.repeat(7).split('')
+            expect(getDayNamesMin()).toBe(window.dayNamesMin)
+        })
+    })
+
+    describe('getMonthNames', () => {
+        // @ts-ignore
+        afterAll(() => { delete window.monthNames })
+
+        it('works without `OC`', () => {
+            expect(getMonthNames().length).toBe(12)
+            // Warning as fallback is being used
+            expect(console.warn).toBeCalled()
+        })
+
+        it('works with `OC`', () => {
+            window.monthNames = 'd'.repeat(12).split('')
+            expect(getMonthNames()).toBe(window.monthNames)
+        })
+    })
+
+    describe('getMonthNamesShort', () => {
+        // @ts-ignore
+        afterAll(() => { delete window.monthNamesShort })
+
+        it('works without `OC`', () => {
+            expect(getMonthNamesShort().length).toBe(12)
+            // Warning as fallback is being used
+            expect(console.warn).toBeCalled()
+        })
+
+        it('works with `OC`', () => {
+            window.monthNamesShort = 'e'.repeat(12).split('')
+            expect(getMonthNamesShort()).toBe(window.monthNamesShort)
+        })
+    })
+})

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -84,27 +84,3 @@ describe('getCanonicalLocale', () => {
         expect(getCanonicalLocale()).toEqual('de-DE')
     })
 })
-
-test('getFirstDay', () => {
-    expect(getFirstDay()).toBe(1)
-})
-
-test('getDayNames', () => {
-    expect(getDayNames().length).toBe(7)
-})
-
-test('getDayNamesShort', () => {
-    expect(getDayNamesShort().length).toBe(7)
-})
-
-test('getDayNamesMin', () => {
-    expect(getDayNamesMin().length).toBe(7)
-})
-
-test('getMonthNames', () => {
-    expect(getMonthNames().length).toBe(12)
-})
-
-test('getMonthNamesShort', () => {
-    expect(getMonthNamesShort().length).toBe(12)
-})


### PR DESCRIPTION
This adds the missing test cases for `date.ts` to increase code coverage of it to 100%.
Mainly this adds tests for `@nextcloud/l10n` to use `window.????`  if provided and also tests for emitting warnings on the console if the defaults are used.

This also adds support for tests written in TypeScript (adds the missing typings).