### PR TITLE
fix(config): fix tsconfig out dir typings

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -10,9 +10,7 @@ const config = (input, output) => ({
 	input,
 	external,
 	plugins: [
-		typescript({
-			declaration: true,
-		}),
+		typescript(),
 	],
 	output: [output],
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
             "dom"
         ]
     },
-    "exclude": ["./dist"]
+    "exclude": ["./dist", "./tests"]
 }


### PR DESCRIPTION
Fix #561 
We need to use the tsconfig, or else it's no use at all.
Removing the overriden declaration in rollup make the rollup plugin fetch the tsconfig.json file 

```bash
$ npm run build 
$ tree dist
dist
├── date.d.ts
├── gettext.d.ts
├── gettext.js
├── gettext.mjs
├── index.d.ts
├── index.js
├── index.mjs
├── registry.d.ts
└── translation.d.ts

0 directories, 9 files
```
