### PR TITLE
Add more tests for `registry.ts` and fix typings

### DIFF
--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -1,4 +1,4 @@
-export type Translations = Record<string, string | undefined>
+export type Translations = Record<string, string | string[] | undefined>
 export type PluralFunction = (number: number) => number
 
 declare let window: {

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -1,10 +1,13 @@
+/// <reference types="@nextcloud/typings" />
 export type Translations = Record<string, string | string[] | undefined>
 export type PluralFunction = (number: number) => number
 
-declare let window: {
-	_oc_l10n_registry_translations: Record<string, Translations>
-	_oc_l10n_registry_plural_functions: Record<string, PluralFunction>
+export interface NextcloudWindowWithRegistry extends Nextcloud.v25.WindowWithGlobals {
+	_oc_l10n_registry_translations?: Record<string, Translations>
+	_oc_l10n_registry_plural_functions?: Record<string, PluralFunction>
 }
+
+declare const window: NextcloudWindowWithRegistry
 
 interface AppTranslations {
 	translations: Translations
@@ -36,12 +39,6 @@ export function registerAppTranslations(
 	translations: Translations,
 	pluralFunction: PluralFunction
 ) {
-	if (window._oc_l10n_registry_translations === undefined) {
-		window._oc_l10n_registry_translations = {}
-	}
-	if (window._oc_l10n_registry_plural_functions === undefined) {
-		window._oc_l10n_registry_plural_functions = {}
-	}
 	if (!hasAppTranslations(appId)) {
 		setAppTranslations(appId, translations, pluralFunction)
 	} else {
@@ -55,8 +52,8 @@ export function registerAppTranslations(
  * @param {string} appId the app id
  */
 export function unregisterAppTranslations(appId: string) {
-	delete window._oc_l10n_registry_translations[appId]
-	delete window._oc_l10n_registry_plural_functions[appId]
+	delete window._oc_l10n_registry_translations?.[appId]
+	delete window._oc_l10n_registry_plural_functions?.[appId]
 }
 
 /**
@@ -90,8 +87,19 @@ function setAppTranslations(
 	translations: Translations,
 	pluralFunction: PluralFunction
 ) {
-	window._oc_l10n_registry_translations[appId] = translations
-	window._oc_l10n_registry_plural_functions[appId] = pluralFunction
+	window._oc_l10n_registry_translations = Object.assign(
+		window._oc_l10n_registry_translations || {},
+		{
+			[appId]: translations,
+		}
+	)
+
+	window._oc_l10n_registry_plural_functions = Object.assign(
+		window._oc_l10n_registry_plural_functions || {},
+		{
+			[appId]: pluralFunction,
+		}
+	)
 }
 
 /**
@@ -106,11 +114,19 @@ function extendAppTranslations(
 	translations: Translations,
 	pluralFunction?: PluralFunction
 ) {
-	window._oc_l10n_registry_translations[appId] = Object.assign(
-		window._oc_l10n_registry_translations[appId],
-		translations
+	window._oc_l10n_registry_translations = Object.assign(
+		window._oc_l10n_registry_translations || {},
+		{
+			[appId]: Object.assign(window._oc_l10n_registry_translations?.[appId] || {}, translations),
+		}
 	)
+
 	if (typeof pluralFunction === 'function') {
-		window._oc_l10n_registry_plural_functions[appId] = pluralFunction
+		window._oc_l10n_registry_plural_functions = Object.assign(
+			window._oc_l10n_registry_plural_functions || {},
+			{
+				[appId]: pluralFunction,
+			}
+		)
 	}
 }

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -39,11 +39,19 @@ export function registerAppTranslations(
 	translations: Translations,
 	pluralFunction: PluralFunction
 ) {
-	if (!hasAppTranslations(appId)) {
-		setAppTranslations(appId, translations, pluralFunction)
-	} else {
-		extendAppTranslations(appId, translations, pluralFunction)
-	}
+	window._oc_l10n_registry_translations = Object.assign(
+		window._oc_l10n_registry_translations || {},
+		{
+			[appId]: Object.assign(window._oc_l10n_registry_translations?.[appId] || {}, translations),
+		}
+	)
+
+	window._oc_l10n_registry_plural_functions = Object.assign(
+		window._oc_l10n_registry_plural_functions || {},
+		{
+			[appId]: pluralFunction,
+		}
+	)
 }
 
 /**
@@ -72,61 +80,5 @@ export function getAppTranslations(appId: string): AppTranslations {
 	return {
 		translations: window._oc_l10n_registry_translations?.[appId] ?? {},
 		pluralFunction: window._oc_l10n_registry_plural_functions?.[appId] ?? ((number: number) => number),
-	}
-}
-
-/**
- * Set new translations and plural function for an app
- *
- * @param {string} appId the app id
- * @param {object} translations the translations list
- * @param {Function} pluralFunction the plural function
- */
-function setAppTranslations(
-	appId: string,
-	translations: Translations,
-	pluralFunction: PluralFunction
-) {
-	window._oc_l10n_registry_translations = Object.assign(
-		window._oc_l10n_registry_translations || {},
-		{
-			[appId]: translations,
-		}
-	)
-
-	window._oc_l10n_registry_plural_functions = Object.assign(
-		window._oc_l10n_registry_plural_functions || {},
-		{
-			[appId]: pluralFunction,
-		}
-	)
-}
-
-/**
- * Extend translations for an app
- *
- * @param {string} appId the app id
- * @param {object} translations the translations list
- * @param {Function} [pluralFunction] the plural function (will override old value if given)
- */
-function extendAppTranslations(
-	appId: string,
-	translations: Translations,
-	pluralFunction?: PluralFunction
-) {
-	window._oc_l10n_registry_translations = Object.assign(
-		window._oc_l10n_registry_translations || {},
-		{
-			[appId]: Object.assign(window._oc_l10n_registry_translations?.[appId] || {}, translations),
-		}
-	)
-
-	if (typeof pluralFunction === 'function') {
-		window._oc_l10n_registry_plural_functions = Object.assign(
-			window._oc_l10n_registry_plural_functions || {},
-			{
-				[appId]: pluralFunction,
-			}
-		)
 	}
 }

--- a/lib/translation.ts
+++ b/lib/translation.ts
@@ -89,7 +89,11 @@ export function translate(
 	const translation = bundle.translations[text] || text
 
 	if (typeof vars === 'object' || number !== undefined) {
-		return optSanitize(_build(translation, vars, number))
+		return optSanitize(_build(
+			typeof translation === 'string' ? translation : translation[0],
+			vars,
+			number
+		))
 	} else {
 		return optSanitize(translation)
 	}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dev": "rollup -c -w",
     "lint": "eslint .",
     "lint:fix": "eslint --fix lib tests",
-    "test": "jest",
+    "test": "jest --verbose",
     "test:watch": "jest --watchAll"
   },
   "keywords": [

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,0 +1,155 @@
+import type { NextcloudWindowWithRegistry } from '../lib/registry'
+
+import {
+	getAppTranslations,
+	hasAppTranslations,
+	registerAppTranslations,
+	unregisterAppTranslations,
+} from '../lib/registry'
+
+declare const window: NextcloudWindowWithRegistry
+
+const clearWindow = () => {
+	delete window._oc_l10n_registry_plural_functions
+	delete window._oc_l10n_registry_translations
+}
+
+const pluralFunction = (number: number) => (number > 1 ? 1 : 0)
+
+const mockWindow = () => {
+	window._oc_l10n_registry_plural_functions = {
+		core: pluralFunction,
+	}
+	window._oc_l10n_registry_translations = {
+		core: {
+			foo: 'foo',
+			'_%n bar_::_%n bars_': [
+				'%n bar',
+				'%n bars',
+			],
+		},
+	}
+}
+
+describe('registry', () => {
+	beforeAll(clearWindow)
+	afterEach(clearWindow)
+
+	test('hasAppTranslations', () => {
+		expect(hasAppTranslations('doesnotexist')).toBe(false)
+
+		mockWindow()
+
+		expect(hasAppTranslations('core')).toBe(true)
+		expect(hasAppTranslations('doesnotexist')).toBe(false)
+
+		// not fully initialized registry
+		delete window._oc_l10n_registry_plural_functions
+		expect(hasAppTranslations('core')).toBe(false)
+	})
+
+	describe('getAppTranslations', () => {
+		const orginalWarn = console.warn
+
+		afterAll(() => {
+			console.warn = orginalWarn
+		})
+		beforeEach(() => {
+			console.warn = jest.fn()
+			clearWindow()
+		})
+
+		it('without translations', () => {
+			const bundle = getAppTranslations('doesnotexist')
+			expect(bundle.translations).toMatchObject({})
+			expect(typeof bundle.pluralFunction === 'function').toBe(true)
+			expect(typeof bundle.pluralFunction(0)).toBe('number')
+			expect(console.warn).toBeCalled()
+		})
+
+		it('with translations', () => {
+			mockWindow()
+
+			let bundle = getAppTranslations('core')
+			expect(Object.keys(bundle.translations).length > 0).toBe(true)
+			expect(bundle.pluralFunction).toBe(pluralFunction)
+			expect(console.warn).toBeCalledTimes(0)
+
+			bundle = getAppTranslations('doesnotexist')
+			expect(bundle.translations).toMatchObject({})
+			expect(typeof bundle.pluralFunction === 'function').toBe(true)
+			expect(console.warn).toBeCalledTimes(1)
+
+			// Expect a warning if some registration is broken
+			delete window._oc_l10n_registry_plural_functions
+			bundle = getAppTranslations('core')
+			expect(console.warn).toBeCalledTimes(2)
+		})
+	})
+
+	describe('unregisterAppTranslations', () => {
+		beforeEach(clearWindow)
+
+		it('works without registry', () => {
+			expect(() => unregisterAppTranslations('doesnotexist')).not.toThrowError()
+		})
+
+		it('works with not registered app', () => {
+			mockWindow()
+
+			expect(() => unregisterAppTranslations('doesnotexist')).not.toThrowError()
+			expect(window._oc_l10n_registry_plural_functions?.core).toBe(pluralFunction)
+			expect(Object.keys(window._oc_l10n_registry_translations?.core || {}).length > 0).toBe(true)
+		})
+
+		it('works with registered app', () => {
+			mockWindow()
+
+			expect(() => unregisterAppTranslations('core')).not.toThrowError()
+			expect(window._oc_l10n_registry_plural_functions?.core).toBe(undefined)
+			expect(window._oc_l10n_registry_translations?.core).toBe(undefined)
+		})
+	})
+
+	describe('registerAppTranslations', () => {
+		beforeEach(clearWindow)
+
+		it('works without registry', () => {
+			const translations = {
+				foo: 'foo',
+			}
+			expect(() => registerAppTranslations('myapp', translations, pluralFunction)).not.toThrowError()
+			expect(window._oc_l10n_registry_translations?.myapp).toMatchObject(translations)
+			expect(window._oc_l10n_registry_plural_functions?.myapp).toBe(pluralFunction)
+		})
+
+		it('works with new app', () => {
+			mockWindow()
+
+			const translations = {
+				foo: 'foo',
+			}
+			expect(() => registerAppTranslations('myapp', translations, pluralFunction)).not.toThrowError()
+			expect(window._oc_l10n_registry_translations?.myapp).toMatchObject(translations)
+			expect(window._oc_l10n_registry_plural_functions?.myapp).toBe(pluralFunction)
+			// Unchanged other apps
+			expect(Object.keys(window._oc_l10n_registry_translations?.core || {}).length > 0).toBe(true)
+			expect(window._oc_l10n_registry_plural_functions?.core).toBe(pluralFunction)
+		})
+
+		it('works with already registered app', () => {
+			const newTranslations = {
+				newvalue: 'newvalue',
+			}
+			mockWindow()
+
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			const numBefore = Object.keys(window._oc_l10n_registry_translations!.core).length
+
+			expect(() => registerAppTranslations('core', newTranslations, pluralFunction)).not.toThrowError()
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			expect(Object.keys(window._oc_l10n_registry_translations!.core).length).toBe(numBefore + 1)
+			expect(window._oc_l10n_registry_plural_functions?.core).toBe(pluralFunction)
+		})
+	})
+})


### PR DESCRIPTION
Found some time today for adding more tests for `registry.ts` to achieve 100% code coverage.
While doing so, by the help of those tests, I noticed types for `Translations` were not correct (plural form of strings).

So this PR includes fixes for the types, as well as some code changes which result from changing the types.
I decided to not squash the commits so might get some context why I changed something the way I did.

### Code coverage

| before | after |
|-----------|--------|
| ![code coverage before, 95.65% statements, 85.71% branches](https://user-images.githubusercontent.com/1855448/213487728-41bde906-fbe0-46de-8a0a-daf4a3733fa5.png) |![code coverage after, 100% statements, 100% branches](https://user-images.githubusercontent.com/1855448/213487472-9e77333b-163c-42f0-8bd3-3ee6fa55d5e7.png) |