### PR TITLE
fix: Remove dead code from previous server implementation

### DIFF
--- a/lib/translation.ts
+++ b/lib/translation.ts
@@ -211,10 +211,6 @@ export function getPlural(number: number) {
 		language = 'xbr'
 	}
 
-	if (typeof language === 'undefined' || language === '') {
-		return number === 1 ? 0 : 1
-	}
-
 	if (language.length > 3) {
 		language = language.substring(0, language.lastIndexOf('-'))
 	}


### PR DESCRIPTION
Our implementation of `getLanguage()` does have a fallback to English, so it does never return `undefined` or an empty string.

This conditional was from the server implementation where `getLanguage` might returned a falsy value.