### PR TITLE
Fix loading translations and add test cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "gettext-parser": "^6.0.0",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
+        "mock-xmlhttprequest": "^8.1.0",
         "rollup": "^3.9.1",
         "ts-jest": "^29.0.3",
         "tslib": "^2.4.1",
@@ -5982,6 +5983,15 @@
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mock-xmlhttprequest": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/mock-xmlhttprequest/-/mock-xmlhttprequest-8.1.0.tgz",
+      "integrity": "sha512-hOpjaDRdWQTscwOME6W50OTT9duY1hm8w7Nx3i5GE35OHseiR3Z2s2Azy1BhpY7dUioiNiL0bs7dfEla3siRnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ms": {
@@ -12483,6 +12493,12 @@
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true,
       "peer": true
+    },
+    "mock-xmlhttprequest": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/mock-xmlhttprequest/-/mock-xmlhttprequest-8.1.0.tgz",
+      "integrity": "sha512-hOpjaDRdWQTscwOME6W50OTT9duY1hm8w7Nx3i5GE35OHseiR3Z2s2Azy1BhpY7dUioiNiL0bs7dfEla3siRnw==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "gettext-parser": "^6.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
+    "mock-xmlhttprequest": "^8.1.0",
     "rollup": "^3.9.1",
     "ts-jest": "^29.0.3",
     "tslib": "^2.4.1",

--- a/tests/loadTranslations.test.ts
+++ b/tests/loadTranslations.test.ts
@@ -1,0 +1,166 @@
+import { MockXhrServer, newServer } from 'mock-xmlhttprequest'
+
+import { loadTranslations, register, translate, _unregister } from '../lib/translation'
+
+const setLocale = (locale) => document.documentElement.setAttribute('data-locale', locale)
+
+describe('loadTranslations', () => {
+	let server: MockXhrServer
+
+	beforeEach(() => {
+		setLocale('de')
+		server = newServer()
+			.addHandler('GET', '/myapp/l10n/de.json', {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					translations: {
+						'Hello world!': 'Hallo Welt!',
+					},
+				}),
+			})
+			.addHandler('GET', '/invalid/l10n/de.json', {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					strings: {
+						'Hello world!': 'Hallo Welt!',
+					},
+				}),
+			})
+			.addHandler('GET', '/empty/l10n/de.json', {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+				body: '',
+			})
+			.addHandler('GET', '/404/l10n/de.json', {
+				status: 404,
+				statusText: 'Not Found',
+			})
+			.addHandler('GET', '/500/l10n/de.json', {
+				status: 500,
+				statusText: 'Internal Server Error',
+			})
+			.addHandler('GET', '/networkissue/l10n/de.json', (req) => req.setNetworkError())
+			.setDefault404()
+		server
+			.disableTimeout()
+		server
+			.install()
+	})
+
+	afterEach(() => {
+		server.remove()
+		jest.clearAllMocks()
+	})
+
+	it('calls callback if app already exists', async () => {
+		register('myapp', {
+			Bye: 'Tschüss',
+		})
+
+		const callback = jest.fn()
+		try {
+			await loadTranslations('myapp', callback)
+			// Callback called
+			expect(callback).toBeCalledTimes(1)
+			// No requests done
+			expect(server.getRequestLog().length).toBe(0)
+			// Old translations work
+			expect(translate('myapp', 'Bye')).toBe('Tschüss')
+			// does not override translations
+			expect(translate('myapp', 'Hello world!')).toBe('Hello world!')
+		} catch (e) {
+			expect(e).toBe('Unexpected error')
+		} finally {
+			_unregister('myapp')
+		}
+	})
+
+	it('calls callback if locale is English', async () => {
+		setLocale('en')
+		const callback = jest.fn()
+
+		try {
+			await loadTranslations('myapp', callback)
+			// Callback called
+			expect(callback).toBeCalledTimes(1)
+			// No requests done
+			expect(server.getRequestLog().length).toBe(0)
+		} catch (e) {
+			expect(e).toBe('Unexpected error')
+		}
+	})
+
+	it('registers new translations', async () => {
+		const callback = jest.fn()
+		try {
+			await loadTranslations('myapp', callback)
+			// Callback called
+			expect(callback).toBeCalledTimes(1)
+			// No requests done
+			expect(server.getRequestLog().length).toBe(1)
+			// New translations work
+			expect(translate('myapp', 'Hello world!')).toBe('Hallo Welt!')
+		} catch (e) {
+			expect(e).toBe('Unexpected error')
+		} finally {
+			console.warn(server.getRequestLog()[0])
+		}
+	})
+
+	it('does reject on network error', async () => {
+		const callback = jest.fn()
+		try {
+			await loadTranslations('networkissue', callback)
+			expect('').toBe('Unexpected pass')
+		} catch (e) {
+			expect(e instanceof Error).toBe(true)
+			expect((<Error>e).message).toBe('Network error')
+		}
+	})
+
+	it('does reject on server error', async () => {
+		const callback = jest.fn()
+		try {
+			await loadTranslations('500', callback)
+			expect('').toBe('Unexpected pass')
+		} catch (e) {
+			expect(e instanceof Error).toBe(true)
+			expect((<Error>e).message).toBe('Internal Server Error')
+		}
+	})
+
+	it('does reject on unavailable bundle', async () => {
+		const callback = jest.fn()
+		try {
+			await loadTranslations('404', callback)
+			expect('').toBe('Unexpected pass')
+		} catch (e) {
+			expect(e instanceof Error).toBe(true)
+			expect((<Error>e).message).toBe('Not Found')
+		}
+	})
+
+	it('does reject on invalid bundle', async () => {
+		const callback = jest.fn()
+		try {
+			await loadTranslations('invalid', callback)
+			expect('').toBe('Unexpected pass')
+		} catch (e) {
+			expect(e instanceof Error).toBe(true)
+			expect((<Error>e).message).toBe('Invalid content of translation bundle')
+		}
+	})
+
+	it('does reject on empty bundle', async () => {
+		const callback = jest.fn()
+		try {
+			await loadTranslations('invalid', callback)
+			expect('').toBe('Unexpected pass')
+		} catch (e) {
+			expect(e instanceof Error).toBe(true)
+			expect((<Error>e).message).toBe('Invalid content of translation bundle')
+		}
+	})
+})


### PR DESCRIPTION
There is a small issue which completely changed the behavior of `loadTranslation` to be synchronous while it should be (and is in `OC.L10N`) asynchronous. This is fixed, also added more information if the request fails.

Added test cases for `loadTranslation`
| before | after |
|---|----|
| ![code coverage 60.91% statements 13.5% branches](https://user-images.githubusercontent.com/1855448/214821148-c203989a-6cf3-4efa-8462-b47c2be88fe7.png) | ![code coverage 80.89% statements 18.85% branches](https://user-images.githubusercontent.com/1855448/214821698-d9ae6836-c966-4707-8f5c-22e5b5ed9697.png) |

