### PR TITLE
Remove warning "No translation for appId "${appId}" have been registered"

### DIFF
--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -103,12 +103,6 @@ export function unregisterAppTranslations(appId: string) {
  * @return {object}
  */
 export function getAppTranslations(appId: string): AppTranslations {
-	if (
-		typeof window._oc_l10n_registry_translations?.[appId] === 'undefined'
-		|| typeof window._oc_l10n_registry_plural_functions?.[appId] === 'undefined'
-	) {
-		console.warn(`No translation for appId "${appId}" have been registered`)
-	}
 	return {
 		translations: window._oc_l10n_registry_translations?.[appId] ?? {},
 		pluralFunction: window._oc_l10n_registry_plural_functions?.[appId] ?? ((number: number) => number),

--- a/tests/gettext.test.js
+++ b/tests/gettext.test.js
@@ -3,9 +3,9 @@ import { po } from 'gettext-parser'
 import { getGettextBuilder } from '../lib/gettext.ts'
 
 describe('gettext', () => {
-
 	beforeEach(() => {
 		jest.spyOn(console, 'warn')
+		console.warn.mockImplementation(() => {})
 	})
 
 	afterEach(() => {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -49,13 +49,7 @@ describe('registry', () => {
 	})
 
 	describe('getAppTranslations', () => {
-		const orginalWarn = console.warn
-
-		afterAll(() => {
-			console.warn = orginalWarn
-		})
 		beforeEach(() => {
-			console.warn = jest.fn()
 			clearWindow()
 		})
 
@@ -64,7 +58,6 @@ describe('registry', () => {
 			expect(bundle.translations).toMatchObject({})
 			expect(typeof bundle.pluralFunction === 'function').toBe(true)
 			expect(typeof bundle.pluralFunction(0)).toBe('number')
-			expect(console.warn).toBeCalled()
 		})
 
 		it('with translations', () => {
@@ -73,17 +66,10 @@ describe('registry', () => {
 			let bundle = getAppTranslations('core')
 			expect(Object.keys(bundle.translations).length > 0).toBe(true)
 			expect(bundle.pluralFunction).toBe(pluralFunction)
-			expect(console.warn).toBeCalledTimes(0)
 
 			bundle = getAppTranslations('doesnotexist')
 			expect(bundle.translations).toMatchObject({})
 			expect(typeof bundle.pluralFunction === 'function').toBe(true)
-			expect(console.warn).toBeCalledTimes(1)
-
-			// Expect a warning if some registration is broken
-			delete window._oc_l10n_registry_plural_functions
-			bundle = getAppTranslations('core')
-			expect(console.warn).toBeCalledTimes(2)
 		})
 	})
 


### PR DESCRIPTION
In 1.x translations registry was initialized in `OC.L10N`. The initialization includes defining global variables on script load: <https://github.com/nextcloud/server/blob/352bd7ecea488201e4162e4e31a0cf9770cf20a0/core/src/OC/l10n-registry.js#L24-L26>

```js
// server/core/src/OC/l10n-registry.js 
window._oc_l10n_registry_translations = window._oc_l10n_registry_translations || {}
window._oc_l10n_registry_plural_functions = window._oc_l10n_registry_plural_functions || {}
```

After an update `@nextcloud/l10n@2.0.0`, the lib becomes independent from the server's `OC.L10N`. But it still required `window._oc_l10n_registry_translations` to be initialized and warned `No OC L10N registry found`.

In https://github.com/nextcloud/nextcloud-l10n/pull/556 it was fixed by defining `window._oc_l10n_registry_translations` on the first registration. But it also added a warning if there is no translation for an app `No translation for appId "${appId}" have been registered`.

The problem is that English translations often are not supposed to be registered. Instead, the translation keys are used. It results in tons of useless warnings in the console and impacts DX.

![image](https://user-images.githubusercontent.com/25978914/214828891-1ffa73e8-6bcc-4d02-9e96-d1263753aa0c.png)

This PR:
- Removes the warning at all and updates tests
- Add `console.warn` mock in gettext tests to make testing silent