### PR TITLE
fix(deps): Make @nextcloud/typings a regular dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/router": "^2.0.0",
+        "@nextcloud/typings": "^1.6.0",
         "dompurify": "^2.4.1",
         "escape-html": "^1.0.3",
         "node-gettext": "^3.0.0"
@@ -17,7 +18,6 @@
       "devDependencies": {
         "@nextcloud/browserslist-config": "^2.3.0",
         "@nextcloud/eslint-config": "^8.2.0",
-        "@nextcloud/typings": "^1.6.0",
         "@rollup/plugin-typescript": "^11.0.0",
         "@types/jest": "^29.2.5",
         "@types/node-gettext": "^3.0",
@@ -1264,7 +1264,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.6.0.tgz",
       "integrity": "sha512-5uIsteFy9Z9/ZaNGE8w8SDgJp+FK8/LeRLgfnakC2pU8eNKTPlQfkiYR163oEI5Xu5YzwdIzf6/roIXdNinhrw==",
-      "dev": true,
       "dependencies": {
         "@types/jquery": "2.0.60"
       },
@@ -1538,8 +1537,7 @@
     "node_modules/@types/jquery": {
       "version": "2.0.60",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.60.tgz",
-      "integrity": "sha512-izi6OBEVrAwaHiqWITjOPBbVtcKZKAXTocJqPZsAKA2lvmbpFEyPSAxgcqmisbiMYj9EvrooUEPLHQeQqVMWAg==",
-      "dev": true
+      "integrity": "sha512-izi6OBEVrAwaHiqWITjOPBbVtcKZKAXTocJqPZsAKA2lvmbpFEyPSAxgcqmisbiMYj9EvrooUEPLHQeQqVMWAg=="
     },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
@@ -9004,7 +9002,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.6.0.tgz",
       "integrity": "sha512-5uIsteFy9Z9/ZaNGE8w8SDgJp+FK8/LeRLgfnakC2pU8eNKTPlQfkiYR163oEI5Xu5YzwdIzf6/roIXdNinhrw==",
-      "dev": true,
       "requires": {
         "@types/jquery": "2.0.60"
       }
@@ -9231,8 +9228,7 @@
     "@types/jquery": {
       "version": "2.0.60",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.60.tgz",
-      "integrity": "sha512-izi6OBEVrAwaHiqWITjOPBbVtcKZKAXTocJqPZsAKA2lvmbpFEyPSAxgcqmisbiMYj9EvrooUEPLHQeQqVMWAg==",
-      "dev": true
+      "integrity": "sha512-izi6OBEVrAwaHiqWITjOPBbVtcKZKAXTocJqPZsAKA2lvmbpFEyPSAxgcqmisbiMYj9EvrooUEPLHQeQqVMWAg=="
     },
     "@types/jsdom": {
       "version": "20.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@nextcloud/router": "^2.0.0",
+    "@nextcloud/typings": "^1.6.0",
     "dompurify": "^2.4.1",
     "escape-html": "^1.0.3",
     "node-gettext": "^3.0.0"
@@ -44,7 +45,6 @@
   "devDependencies": {
     "@nextcloud/browserslist-config": "^2.3.0",
     "@nextcloud/eslint-config": "^8.2.0",
-    "@nextcloud/typings": "^1.6.0",
     "@rollup/plugin-typescript": "^11.0.0",
     "@types/jest": "^29.2.5",
     "@types/node-gettext": "^3.0",


### PR DESCRIPTION
This ensures that dependents of `@nextcloud/l10n` get the typings.

This follows the suggestions of https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies.

Fixes https://github.com/nextcloud/nextcloud-l10n/issues/609