### PR TITLE
fix: Add the typings to the package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./gettext": {
+      "types": "./dist/gettext.d.ts",
       "import": "./dist/gettext.mjs",
       "require": "./dist/gettext.js"
     }


### PR DESCRIPTION
This is required to make the package work with typescript projects which set the module resolution to `node16` or `nodenext` (only the `exports` field is evaluated but not the `types` field).