### PR TITLE
fix: Update exported `NextcloudWindowWithRegistry` type

### DIFF
--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,6 +1,6 @@
 /// <reference types="@nextcloud/typings" />
 
-declare let window: Nextcloud.v24.WindowWithGlobals
+declare let window: Nextcloud.v27.WindowWithGlobals
 
 /**
  * Get the first day of the week

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -34,7 +34,7 @@ export type PluralFunction = (number: number) => number
  *
  * @private
  */
-export interface NextcloudWindowWithRegistry extends Nextcloud.v25.WindowWithGlobals {
+export interface NextcloudWindowWithRegistry extends Nextcloud.v27.WindowWithGlobals {
 	_oc_l10n_registry_translations?: Record<string, Translations>
 	_oc_l10n_registry_plural_functions?: Record<string, PluralFunction>
 }


### PR DESCRIPTION
Updates the exported window typing to the latest Nextcloud typings (Nextcloud 27).

(Side note: We should maybe provide a `Nextcloud.latest.`  namespace on the typings package).