### PR TITLE
Prepare new release: v2.2.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-node_modules/
-.github/
-lib/
-tests/
-.eslint*
-*.config.*
-tsconfig.json
-typedoc.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.2.0 - 2023-06-26
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-l10n/compare/v2.1.0...v2.2.0)
+
+### Added
+- `isRTL` was added to check whether a given, or the current, language is read right-to-left [\#639](https://github.com/nextcloud/nextcloud-l10n/pull/639) ([susnux](https://github.com/susnux))
+
+### Fixed
+- Add typings to the package exports to fix build for Typescript projects using `node16` or `nodenext` module resolution [\#633](https://github.com/nextcloud/nextcloud-l10n/pull/633) ([susnux](https://github.com/susnux))
+- Update exported `NextcloudWindowWithRegistry` type for Nextcloud 27 [\#640](https://github.com/nextcloud/nextcloud-l10n/pull/640) ([susnux](https://github.com/susnux))
+
+### Changed
+- Update node engines to next LTS (Node 20 + NPM 9)
+- Dependency updates
+
 ## 2.1.0 - 2023-02-25
 
 [Full Changelog](https://github.com/nextcloud/nextcloud-l10n/compare/v2.0.1...v2.1.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/l10n",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/l10n",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/router": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nextcloud/l10n",
-  "version": "2.1.0",
-  "description": "",
+  "version": "2.2.0",
+  "description": "Nextcloud L10n helpers for apps and libraries",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -68,5 +68,9 @@
   "engines": {
     "node": "^20.0.0",
     "npm": "^9.0.0"
-  }
+  },
+  "files": [
+    "CHANGELOG.md",
+    "dist"
+  ]
 }


### PR DESCRIPTION
If accepted, could someone of you with admin permission create the GH release so the NPM release workflow works?

---

## 2.2.0
### Added
- `isRTL` was added to check whether a given, or the current, language is read right-to-left [\#639](https://github.com/nextcloud/nextcloud-l10n/pull/639) ([susnux](https://github.com/susnux))

### Fixed
- Add typings to the package exports to fix build for Typescript projects using `node16` or `nodenext` module resolution [\#633](https://github.com/nextcloud/nextcloud-l10n/pull/633) ([susnux](https://github.com/susnux))
- Update exported `NextcloudWindowWithRegistry` type for Nextcloud 27 [\#640](https://github.com/nextcloud/nextcloud-l10n/pull/640) ([susnux](https://github.com/susnux))

### Changed
- Update node engines to next LTS (Node 20 + NPM 9)
- Dependency updates